### PR TITLE
[FEATURE] Automatically enable installed extensions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -94,6 +94,7 @@
       "vendor/bin/cghooks update"
     ],
     "post-autoload-dump": [
+      "typo3cms install:generatepackagestates"
     ],
     "post-create-project-cmd": [
       "composer env"


### PR DESCRIPTION
Run `typo3cms install:generatepackagestates` in Composer "post-autoload-dump" to write PackageStates.php. Prevents having to manually enable each installed extension. With Composer mode enabled, all required extensions should also be enabled in TYPO3.
