### PR TITLE
[BUGFIX] Dev condition on platform.sh + branch name

### DIFF
--- a/.localconf/platformsh/public/typo3conf/PlatformshConfiguration.php
+++ b/.localconf/platformsh/public/typo3conf/PlatformshConfiguration.php
@@ -64,8 +64,8 @@ if ($platformConfig->hasRelationship('rediscache')) {
         ];
     }
 
-    // TYPO3_CONTEXT Development in Platform SH
-    if (getenv("PLATFORM_BRANCH") === 'development') {
+    // Development in Platform SH
+    if (getenv('PLATFORM_ENVIRONMENT_TYPE') === 'development') {
         // BE
         $GLOBALS['TYPO3_CONF_VARS']['BE']['sessionTimeout'] = 28800;
         $GLOBALS['TYPO3_CONF_VARS']['BE']['debug'] = true;
@@ -74,13 +74,15 @@ if ($platformConfig->hasRelationship('rediscache')) {
         $GLOBALS['TYPO3_CONF_VARS']['FE']['debug'] = true;
 
         // SYS
-        $GLOBALS['TYPO3_CONF_VARS']['SYS']['sitename'] = 'TYPO3 :: t3kit11 :: Dev mode';
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['sitename'] .= ' :: DEV ' . getenv('PLATFORM_BRANCH');
         $GLOBALS['TYPO3_CONF_VARS']['SYS']['devIPmask'] = '*';
 
         $GLOBALS['TYPO3_CONF_VARS']['SYS']['displayErrors'] = 1;
         $GLOBALS['TYPO3_CONF_VARS']['SYS']['exceptionalErrors'] = 28674;
         $GLOBALS['TYPO3_CONF_VARS']['SYS']['errorHandlerErrors'] = 30466;
         $GLOBALS['TYPO3_CONF_VARS']['SYS']['belogErrorReporting'] = 30711;
+    } else {
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['sitename'] .= ' :: PROD';
     }
 }
 


### PR DESCRIPTION
Corrects the condition for development settings on Platform.sh. Also adds "DEV" and the current environment name to `$GLOBALS['TYPO3_CONF_VARS']['SYS']['sitename']`. For production, "PROD" is added. This helps differentiate environments. 

TYPO3_CONTEXT is not set (it wasn't before either). This should be done with an environment variable.

# New Pull Request checklist

## Please check if your PR fulfills the following requirements

- [ ] Contributing to t3kit: <https://github.com/t3kit/.github/blob/master/CONTRIBUTING.md>
- [ ] Coding Rules: <https://github.com/t3kit/.github/blob/master/CONTRIBUTING.md#coding-rules>
- [ ] Commit message conventions: <https://github.com/t3kit/.github/blob/master/CONTRIBUTING.md#commit-message-guidelines>

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] [FEATURE] - A new feature
- [x] [BUGFIX] - A bug fix
- [ ] [TASK] - Any task, which is not a **new feature** or **bugfix**
- [ ] [TEST] - Adding missing tests
- [ ] [DOC] - Documentation only changes
- [ ] [WIP] - Work in progress tag, should not be present when creating pull requests

## Breaking change

Does this PR introduce a breaking change?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please add a [!!!] label at the beginning of the commit message. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Issue references

Issue Number: #...

## Description
<!-- Please add a context and reasoning around your changes, to help us merge quickly. -->
